### PR TITLE
[FE] fix: 로그인해야하는 부분에서 token이 문제 있을 시 reissue token

### DIFF
--- a/service-apply/src/apis/registration.apis.ts
+++ b/service-apply/src/apis/registration.apis.ts
@@ -15,7 +15,7 @@ export const postRegistration = async (
 ): Promise<RegistrationResponse> => {
   const response = await https.post('/v1/registration', data);
   if (isErrorResponse(response)) {
-    if (response.status === 401 || response.status === 403) {
+    if (response.code === 'AUTH_401_1') {
       return reissueToken(() => postRegistration(data));
     }
     console.log(response.reason);
@@ -29,7 +29,7 @@ export const postTemporarySave = async (
 ): Promise<RegistrationResponse> => {
   const response = await https.post('/v1/registration/temporary', data);
   if (isErrorResponse(response)) {
-    if (response.status === 401 || response.status === 403) {
+    if (response.code === 'AUTH_401_1') {
       return reissueToken(() => postTemporarySave(data));
     }
     throw new Error(response.reason);
@@ -41,7 +41,7 @@ export const getRegistration =
   async (): Promise<RegistrationOptionsResponse> => {
     const response = await https.get('/v1/registration');
     if (isErrorResponse(response)) {
-      if (response.status === 401 || response.status === 403) {
+      if (response.code === 'AUTH_401_1') {
         return reissueToken(getRegistration);
       }
       return new RegistrationOptionsResponse({

--- a/service-manager/src/apis/announce.apis.ts
+++ b/service-manager/src/apis/announce.apis.ts
@@ -1,6 +1,7 @@
 import { https } from '../functions/https';
 import { AllAnnounce, Announce, AnnounceDelete } from './dtos/announce.dtos';
 import { isErrorResponse } from './dtos/response.dtos';
+import { reissueToken } from './user.apis';
 
 export const getAllAnnounce = async (page: number) => {
   const response = await https.get(`/v1/announce?page=${page}`);
@@ -23,9 +24,14 @@ export interface AnnounceRequest {
   announceContent: string;
 }
 
-export const postAnnounce = async (data: AnnounceRequest) => {
+export const postAnnounce = async (
+  data: AnnounceRequest,
+): Promise<Announce> => {
   const response = await https.post('/v1/announce', data);
   if (isErrorResponse(response)) {
+    if (response.code === 'AUTH_401_1') {
+      return reissueToken(() => postAnnounce(data));
+    }
     throw new Error(response.reason);
   }
   return new Announce(response);
@@ -37,17 +43,25 @@ export const putAnnounceById = async ({
 }: {
   announceId: number;
   data: AnnounceRequest;
-}) => {
+}): Promise<Announce> => {
   const response = await https.put(`/v1/announce/${announceId}`, data);
   if (isErrorResponse(response)) {
+    if (response.code === 'AUTH_401_1') {
+      return reissueToken(() => putAnnounceById({ announceId, data }));
+    }
     throw new Error(response.reason);
   }
   return new Announce(response);
 };
 
-export const deleteAnnounceById = async (announceId: number) => {
+export const deleteAnnounceById = async (
+  announceId: number,
+): Promise<AnnounceDelete> => {
   const response = await https.delete(`/v1/announce/${announceId}`);
   if (isErrorResponse(response)) {
+    if (response.code === 'AUTH_401_1') {
+      return reissueToken(() => deleteAnnounceById(announceId));
+    }
     throw new Error(response.reason);
   }
   return new AnnounceDelete(response);

--- a/service-manager/src/apis/dtos/sector.dtos.ts
+++ b/service-manager/src/apis/dtos/sector.dtos.ts
@@ -28,3 +28,15 @@ export class Sector {
     this.issueAmount = issueAmount;
   }
 }
+
+class MessageResponse {
+  message: string;
+  constructor({ message }: { message: string }) {
+    this.message = message;
+  }
+}
+
+export class PutSectorResponse extends MessageResponse {}
+export class PostSectorResponse extends MessageResponse {}
+export class DeleteSectorResponse extends MessageResponse {}
+export class PostSettingsResponse extends MessageResponse {}

--- a/service-manager/src/apis/dtos/user.dtos.ts
+++ b/service-manager/src/apis/dtos/user.dtos.ts
@@ -60,3 +60,12 @@ export class PasswordReset {
 
 export class UserSignUpResponse extends JustMessage {}
 export class CheckEmailResponse extends JustMessage {}
+
+export class AdminRoleResponse {
+  userId: number;
+  role: Role;
+  constructor({ userId, role }: { userId: number; role: Role }) {
+    this.userId = userId;
+    this.role = role;
+  }
+}

--- a/service-manager/src/apis/notice.apis.ts
+++ b/service-manager/src/apis/notice.apis.ts
@@ -1,6 +1,7 @@
 import { https } from '../functions/https';
 import { Notice } from './dtos/notice.dtos';
 import { isErrorResponse } from './dtos/response.dtos';
+import { reissueToken } from './user.apis';
 
 export const getNotice = async () => {
   const response = await https.get('/v1/notice');
@@ -10,9 +11,14 @@ export const getNotice = async () => {
   return new Notice(response);
 };
 
-export const putNotice = async (data: { noticeContent: string }) => {
+export const putNotice = async (data: {
+  noticeContent: string;
+}): Promise<Notice> => {
   const response = await https.put('/v1/notice', data);
   if (isErrorResponse(response)) {
+    if (response.code === 'AUTH_401_1') {
+      return reissueToken(() => putNotice(data));
+    }
     throw new Error(response.reason);
   }
   return new Notice(response);

--- a/service-manager/src/apis/registration.apis.ts
+++ b/service-manager/src/apis/registration.apis.ts
@@ -1,10 +1,14 @@
 import { https } from '../functions/https';
 import { RegistrationResponse } from './dtos/registration.dto';
 import { isErrorResponse } from './dtos/response.dtos';
+import { reissueToken } from './user.apis';
 
 export const getAllRegistration = async (): Promise<RegistrationResponse[]> => {
   const response = await https.get('/v1/registrations');
   if (isErrorResponse(response)) {
+    if (response.code === 'AUTH_401_1') {
+      return reissueToken(getAllRegistration);
+    }
     throw new Error(response.reason);
   }
   return response.registrations.map(

--- a/service-manager/src/apis/settings.apis.ts
+++ b/service-manager/src/apis/settings.apis.ts
@@ -1,7 +1,14 @@
 import { https } from '../functions/https';
 import { isErrorResponse } from './dtos/response.dtos';
-import { Sector } from './dtos/sector.dtos';
+import {
+  DeleteSectorResponse,
+  PostSectorResponse,
+  PostSettingsResponse,
+  PutSectorResponse,
+  Sector,
+} from './dtos/sector.dtos';
 import { SettingTime } from './dtos/times.dtos';
+import { reissueToken } from './user.apis';
 
 interface SectorRequest {
   name: string;
@@ -13,33 +20,51 @@ interface SectorRequest {
 export const getSectors = async (): Promise<Sector[]> => {
   const response = await https.get('/v1/sectors');
   if (isErrorResponse(response)) {
+    if (response.code === 'AUTH_401_1') {
+      return reissueToken(getSectors);
+    }
     throw new Error(response.reason);
   }
   return response.map((sector: any) => new Sector(sector));
 };
 
-export const putSectors = async (data: SectorRequest[]) => {
+export const putSectors = async (
+  data: SectorRequest[],
+): Promise<PutSectorResponse> => {
   const response = await https.put('/v1/sectors', data);
   if (isErrorResponse(response)) {
+    if (response.code === 'AUTH_401_1') {
+      return reissueToken(() => putSectors(data));
+    }
     throw new Error(response.reason);
   }
-  return response;
+  return new PutSectorResponse(response);
 };
 
-export const postSectors = async (data: SectorRequest[]) => {
+export const postSectors = async (
+  data: SectorRequest[],
+): Promise<PostSectorResponse> => {
   const response = await https.post('/v1/sectors', data);
   if (isErrorResponse(response)) {
+    if (response.code === 'AUTH_401_1') {
+      return reissueToken(() => postSectors(data));
+    }
     throw new Error(response.reason);
   }
-  return response;
+  return new PostSectorResponse(response);
 };
 
-export const deleteSector = async (sectorNumber: string) => {
+export const deleteSector = async (
+  sectorNumber: string,
+): Promise<DeleteSectorResponse> => {
   const response = await https.delete(`/v1/sectors/${sectorNumber}`);
   if (isErrorResponse(response)) {
+    if (response.code === 'AUTH_401_1') {
+      return reissueToken(() => deleteSector(sectorNumber));
+    }
     throw new Error(response.reason);
   }
-  return response;
+  return new DeleteSectorResponse(response);
 };
 
 export const getSettingTime = async () => {
@@ -50,14 +75,19 @@ export const getSettingTime = async () => {
   return new SettingTime(response);
 };
 
-export const postSettingTime = async (date: SettingTime) => {
+export const postSettingTime = async (
+  date: SettingTime,
+): Promise<PostSettingsResponse> => {
   const datesString = {
     startAt: date.startAt.toISOString().slice(0, 19),
     endAt: date.endAt.toISOString().slice(0, 19),
   };
   const response = await https.post(`/v1/events`, datesString);
   if (isErrorResponse(response)) {
+    if (response.code === 'AUTH_401_1') {
+      return reissueToken(() => postSettingTime(date));
+    }
     throw new Error(response.reason);
   }
-  return response as { message: string };
+  return new PostSettingsResponse(response);
 };

--- a/service-manager/src/apis/user.apis.ts
+++ b/service-manager/src/apis/user.apis.ts
@@ -1,5 +1,5 @@
 import { https } from '../functions/https';
-import { removeToken, setToken } from '../functions/jwt';
+import { getRefreshToken, removeToken, setToken } from '../functions/jwt';
 import type { Role } from '../types/admin';
 import { isErrorResponse } from './dtos/response.dtos';
 import {
@@ -9,6 +9,7 @@ import {
   UserSignUpResponse,
   Council,
   CheckEmailResponse,
+  AdminRoleResponse,
 } from './dtos/user.dtos';
 
 export interface UserLoginRequest {
@@ -74,12 +75,12 @@ export const reissueToken = async <T>(retryCallback: () => T): Promise<T> => {
   const token = localStorage.getItem('refreshToken');
 
   if (!token) {
-    throw new Error('Refresh token not found');
+    throw new Error('로그인을 해주세요.');
   }
   const response = await https.post('/v1/auth/login', { refreshtoken: token });
   if (isErrorResponse(response)) {
     removeToken();
-    throw new Error(response.reason);
+    throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
   }
 
   setToken(new UserToken(response));
@@ -92,12 +93,15 @@ export const putAdminRole = async ({
 }: {
   userId: number;
   role: Role;
-}) => {
+}): Promise<AdminRoleResponse> => {
   const response = await https.put(`/v1/admin/role/${userId}`, { role });
   if (isErrorResponse(response)) {
+    if (response.code === 'AUTH_401_1') {
+      return reissueToken(() => putAdminRole({ userId, role }));
+    }
     throw new Error(response.reason);
   }
-  return response;
+  return new AdminRoleResponse(response);
 };
 
 export const getAllCouncils = async () => {


### PR DESCRIPTION
## 주요 변경사항

- 기존에 있던 reissueToken에 대한 부분을 BE가 제공하는 code 'AUTH_401_1'를 이용하여 다시 받아오게 했습니다.

## 리뷰어에게...

- 로직의 경우에 무한 루프가 빠질 수 있는 것 처럼 보이지만, BE에서 제대로 에러만 던져준다면 그럴일은 없어 보입니다.
- 다만 이 로직이 이렇게 가는것이 맞을지 걱정입니다.
- 이 로직을 api에서 짠 이유는, reissue token이 api단에 있고, funtions에서 해치고 싶지 않아서 입니다.

## 관련 이슈

- closes #106 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정
