### PR TITLE
[FE] fix(manager): 모든 이벤트가 CLOSED가 됐을 때 생성 가능하도록 변경

### DIFF
--- a/service-manager/src/hooks/useSetting/useSectionBoard.tsx
+++ b/service-manager/src/hooks/useSetting/useSectionBoard.tsx
@@ -3,17 +3,12 @@ import { useSettingEventsQuery } from '../react-query/useSetting';
 export const useSectionBoard = (pageIndex: number) => {
   const { coupon } = useSettingEventsQuery(pageIndex);
   let checkCoupon = coupon;
-  let canCreate = true;
   if (pageIndex !== 1) {
     const { coupon } = useSettingEventsQuery(1);
     checkCoupon = coupon;
   }
-  if (
-    coupon.couponEvents.some(
-      (event) => event.eventStatus === 'OPEN' || event.eventStatus === 'READY',
-    )
-  ) {
-    canCreate = false;
-  }
+  const canCreate = !coupon.couponEvents.some(
+    (event) => event.eventStatus === 'OPEN' || event.eventStatus === 'READY',
+  );
   return { coupon, canCreate };
 };


### PR DESCRIPTION
## 주요 변경사항
- 모든 event가 CLOSED상태 여야 이벤트 생성 가능하도록 변경했습니다.
![image](https://github.com/JNU-Parking-Ticket-Project/Parking-Ticket-FE/assets/77495584/fce2fb22-d771-4b72-98dc-c80cc8e4ce1e)

## 리뷰어에게...
- 재선언된 checkCoupon을 사용하지 않는 코드가 되어버렸습니다...이부분에 대한 이해가 부족한데 리뷰 부탁드립니다.
## 관련 이슈

closes
- #147
## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정
