### PR TITLE
[FE] refactor(manager): 로그아웃 버튼 상태관리 

### DIFF
--- a/service-manager/src/apis/settings.apis.ts
+++ b/service-manager/src/apis/settings.apis.ts
@@ -81,9 +81,12 @@ export const deleteSector = async (
   return new DeleteSectorResponse(response);
 };
 
-export const getSettingReadyTime = async () => {
+export const getSettingReadyTime = async (): Promise<SettingTime> => {
   const response = await https.get(`/v1/events/period`);
   if (isErrorResponse(response)) {
+    if (getErrorContent(response.code).type === 'REISSUE') {
+      return reissueToken(getSettingReadyTime);
+    }
     throw new Error(response.reason);
   }
   return new SettingTime(response);
@@ -119,17 +122,25 @@ export const postSettingTime = async (
   return new PostSettingsResponse(response);
 };
 
-export const getSettingEvents = async (page: number) => {
+export const getSettingEvents = async (page: number): Promise<CouponEvent> => {
   const response = await https.get(`/v1/events?page=${page}`);
   if (isErrorResponse(response)) {
+    if (getErrorContent(response.code).type === 'REISSUE') {
+      return reissueToken(() => getSettingEvents(page));
+    }
     throw new Error(response.reason);
   }
   return new CouponEvent(response);
 };
 
-export const getSettingEventBy = async (eventId: string) => {
+export const getSettingEventBy = async (
+  eventId: string,
+): Promise<CouponEventDetail> => {
   const response = await https.get(`/v1/events/${eventId}`);
   if (isErrorResponse(response)) {
+    if (getErrorContent(response.code).type === 'REISSUE') {
+      return reissueToken(() => getSettingEventBy(eventId));
+    }
     throw new Error(response.reason);
   }
   return new CouponEventDetail(response);

--- a/service-manager/src/apis/user.apis.ts
+++ b/service-manager/src/apis/user.apis.ts
@@ -83,7 +83,8 @@ export const reissueToken = async <T>(retryCallback: () => T): Promise<T> => {
   const token = localStorage.getItem('refreshToken');
 
   if (!token) {
-    throw new Error('로그인을 해주세요.');
+    alert('로그인을 다시 시도해주세요.');
+    location.href = '/';
   }
   const response = await https.post('/v1/auth/login', { refreshtoken: token });
   if (isErrorResponse(response)) {

--- a/service-manager/src/functions/error.ts
+++ b/service-manager/src/functions/error.ts
@@ -49,11 +49,16 @@ export type ERROR_CODE =
   | 'ANNOUNCE_404_2'
   | 'DECRYPTION_500_1'
   | 'ENCRYPTION_500_1'
-  | 'NOTICE_404_1';
+  | 'NOTICE_404_1'
+  | 'AUTH_401_2';
 
 export const getErrorContent = (error: ERROR_CODE): ERROR_TYPE => {
   switch (error) {
     case 'AUTH_401_1':
+      return {
+        type: 'REISSUE',
+      };
+    case 'AUTH_401_2':
       return {
         type: 'REISSUE',
       };


### PR DESCRIPTION
## 주요 변경사항
- 로그아웃 시, 홈페이지로 이동하지 않던 오류를 해결했습니다.
- AUTH 401_2 에러가 오면, reissue errorContent를 뱉고, refreshToken이 없다면 홈으로 redirect되게, 아니면 reissue를 하도록 하였습니다.
## 리뷰어에게...

## 관련 이슈

closes #144 

