### PR TITLE
feat(manager): 이벤트 제목의 길이가 0일시 저장이 되지않게 변경

### DIFF
--- a/service-manager/src/components/setting/SettingCreateTime.tsx
+++ b/service-manager/src/components/setting/SettingCreateTime.tsx
@@ -90,6 +90,10 @@ export const SettingCreateTime = () => {
         size="small"
         className="float-right my-4"
         onClick={() => {
+          if (!title.length) {
+            alert('제목을 입력해주세요.');
+            return;
+          }
           updateSettingTime({
             startAt: openDate,
             endAt: endDate,

--- a/service-manager/src/components/setting/SettingTime.tsx
+++ b/service-manager/src/components/setting/SettingTime.tsx
@@ -107,6 +107,10 @@ export const SettingTime = ({ eventId }: { eventId: string }) => {
           size="small"
           className="float-right my-4"
           onClick={() => {
+            if (!title.length) {
+              alert('제목을 입력해주세요.');
+              return;
+            }
             updateSettingTime({
               startAt: openDate,
               endAt: endDate,


### PR DESCRIPTION
## 주요 변경사항
- 이벤트 제목의 길이가 0일시 요청이 아예가지않도록 간단한 방어코드를 작성하였습니다.

## 관련 이슈

- closes #160

