### PR TITLE
feat(apply): 임시저장시 구간/소속대학이 안뜨는 문제

### DIFF
--- a/service-apply/src/components/apply/ApplyForm.tsx
+++ b/service-apply/src/components/apply/ApplyForm.tsx
@@ -110,12 +110,18 @@ export const ApplyForm = () => {
           name="affiliation"
           type="text"
           options={AFFILIATION_LIST}
+          value={state.affiliation}
           onChange={(e) =>
             dispatch({ type: 'affiliation', payload: e.target.value })
           }
           required
         />
         <ApplySelector
+          value={
+            parkingSectionOptions.find(
+              (section) => '' + state.section === section.value,
+            )?.value ?? '선택'
+          }
           label="구간"
           type="text"
           options={parkingSectionOptions}

--- a/service-apply/src/components/apply/ApplySelector.tsx
+++ b/service-apply/src/components/apply/ApplySelector.tsx
@@ -9,12 +9,14 @@ interface ApplySelectorProps
     label: string;
     value: string;
   }[];
+  value: string;
 }
 
 export const ApplySelector = ({
   label,
   type,
   options,
+  value,
   ...props
 }: ApplySelectorProps) => {
   const id = useId();
@@ -26,6 +28,7 @@ export const ApplySelector = ({
         {props.required && <Txt color="error">*</Txt>}
       </label>
       <select
+        value={value}
         {...props}
         id={id}
         className="p-2 border border-[#D9D9D9] col-span-4 rounded-md"


### PR DESCRIPTION
## 주요 변경사항
- 임시저장 시에 구간과 소속대학이 안뜨는 문제가 있었습니다.
- 조금 끼워맞추긴 했는데... ApplySelector는 다시 구조조정이 필요합니다.
![image](https://github.com/JNU-Parking-Ticket-Project/Parking-Ticket-FE/assets/56749516/95deda04-de8e-4ef8-88f6-9755944e72b5)
