### PR TITLE
refactor(apply): 불러온 구간을 selector에서 사전 순으로 정렬

### DIFF
--- a/service-apply/src/components/apply/ApplyForm.tsx
+++ b/service-apply/src/components/apply/ApplyForm.tsx
@@ -15,6 +15,24 @@ import ErrorBoundary from '../common/ErrorBoundary';
 import { AFFILIATION_LIST } from '../../constants/affiliation';
 import { PrivacyCheckModal } from './PrivacyCheckModal';
 
+const DEFAULT_PARKING_SECTION_OPTIONS = [
+  {
+    label: '선택',
+    value: '0',
+  },
+];
+
+const extractParkingSectionOptionsBySector = (sector: {
+  sectorId: number;
+  sectorNum: string;
+  sectorName: string;
+}) => {
+  return {
+    label: `${sector.sectorNum}-${sector.sectorName}`,
+    value: sector.sectorId.toString(),
+  };
+};
+
 export const ApplyInputText = ({
   className,
   disabled,
@@ -53,18 +71,9 @@ export const ApplyForm = () => {
     errorMessage,
   } = useApplyForm();
 
-  const parkingSection = sector.map((item) => ({
-    sectionNumber: item.sectorId,
-    sectionMajor: `${item.sectorNum}-${item.sectorName}`,
-  }));
-  parkingSection.unshift({ sectionMajor: '선택', sectionNumber: 0 });
-
-  const parkingSectionOptions = parkingSection
-    .sort((a, b) => a.sectionMajor.localeCompare(b.sectionMajor))
-    .map((item) => ({
-      label: item.sectionMajor,
-      value: item.sectionNumber.toString(),
-    }));
+  const parkingSectionOptions = DEFAULT_PARKING_SECTION_OPTIONS.concat(
+    sector.map(extractParkingSectionOptionsBySector),
+  ).sort((a, b) => a.value.localeCompare(b.value));
 
   return (
     <ApplyFormContext.Provider value={state}>


### PR DESCRIPTION
## 주요 변경사항
- 가장 많이 쓰는 것 같은 사전순 배열 코드 블로깅 해서 가져왔는데 숫자, 한글 순서는 확인했는데 이대로 사용해도 괜찮을지 확인 부탁드립니다. 
