### PR TITLE
feat: 로딩인디케이터 개선 및 신청 폼 사용성 개선

### DIFF
--- a/service-apply/src/components/apply/ApplyCaptchaModal.tsx
+++ b/service-apply/src/components/apply/ApplyCaptchaModal.tsx
@@ -1,16 +1,18 @@
 import { Modal, Txt } from '@quokka/design-system';
 import { CaptchaForm } from './CaptchaForm';
-import { Spinner } from '../../assets/Spinner';
 import { useCaptchaForm } from '../../hooks/apply/useCaptchaForm';
+import Loader from '../common/Loader';
 
 interface ApplyCaptchaModalProps {
   isOpen: boolean;
   onRequestClose: () => void;
+  safeClose: () => void;
 }
 
 export const ApplyCaptchaModal = ({
   isOpen,
   onRequestClose,
+  safeClose,
 }: ApplyCaptchaModalProps) => {
   const { isLoading, input, handleInput, captchaImageUrl, handleSubmit } =
     useCaptchaForm({
@@ -21,7 +23,7 @@ export const ApplyCaptchaModal = ({
     <Modal
       className="captcha-modal"
       isOpen={isOpen}
-      onRequestClose={onRequestClose}
+      onRequestClose={safeClose}
       overLayCss={{
         display: 'flex',
         justifyContent: 'center',
@@ -37,15 +39,15 @@ export const ApplyCaptchaModal = ({
       }}
     >
       {isLoading ? (
-        <div className="flex flex-col justify-center align-center">
-          <Txt size="h6" className="text-center">
+        <div className="flex flex-col justify-center align-center gap-1">
+          <Txt size="h6" className="text-center font-bold">
             신청 접수 중입니다. 잠시만 기다려주세요.
           </Txt>
           <Txt size="h6" className="text-center">
-            새로고침 시 신청이 취소됩니다.
+            새로고침하거나 모달 바깥창을 누르면 신청이 취소됩니다.
           </Txt>
-          <div className="w-full">
-            <Spinner />
+          <div className="w-full flex justify-center mt-4">
+            <Loader color="#0255D5" />
           </div>
         </div>
       ) : (

--- a/service-apply/src/components/apply/ApplyForm.tsx
+++ b/service-apply/src/components/apply/ApplyForm.tsx
@@ -64,8 +64,9 @@ export const ApplyForm = () => {
     isPrivacyModalOpen,
     setIsPrivacyModalOpen,
     isCaptchaModalOpen,
-    setIsCaptchaModalOpen,
     onCaptchaModalOpen,
+    onCaptchaModalClose,
+    onCaptchaModalSafeClose,
     isAgreed,
     setIsAgreed,
     isError,
@@ -225,12 +226,8 @@ export const ApplyForm = () => {
             <ErrorBoundary>
               <ApplyCaptchaModal
                 isOpen={isCaptchaModalOpen}
-                safeClose={() => {
-                  window.confirm(
-                    '창을 닫으면 신청을 취소합니다. 창을 닫으시겠습니까?',
-                  ) && setIsCaptchaModalOpen(false);
-                }}
-                onRequestClose={() => setIsCaptchaModalOpen(false)}
+                safeClose={onCaptchaModalSafeClose}
+                onRequestClose={onCaptchaModalClose}
               />
             </ErrorBoundary>
           </Suspense>

--- a/service-apply/src/components/apply/ApplyForm.tsx
+++ b/service-apply/src/components/apply/ApplyForm.tsx
@@ -225,9 +225,12 @@ export const ApplyForm = () => {
             <ErrorBoundary>
               <ApplyCaptchaModal
                 isOpen={isCaptchaModalOpen}
-                onRequestClose={() => {
-                  setIsCaptchaModalOpen(false);
+                safeClose={() => {
+                  window.confirm(
+                    '창을 닫으면 신청을 취소합니다. 창을 닫으시겠습니까?',
+                  ) && setIsCaptchaModalOpen(false);
                 }}
+                onRequestClose={() => setIsCaptchaModalOpen(false)}
               />
             </ErrorBoundary>
           </Suspense>

--- a/service-apply/src/components/common/Loader.css
+++ b/service-apply/src/components/common/Loader.css
@@ -1,0 +1,92 @@
+.lds-roller {
+  /* color: #1c4c5b; */
+}
+.lds-roller,
+.lds-roller div,
+.lds-roller div:after {
+  box-sizing: border-box;
+}
+.lds-roller {
+  display: inline-block;
+  position: relative;
+  width: 80px;
+  height: 80px;
+}
+.lds-roller div {
+  animation: lds-roller 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+  transform-origin: 40px 40px;
+}
+.lds-roller div:after {
+  content: ' ';
+  display: block;
+  position: absolute;
+  width: 7.2px;
+  height: 7.2px;
+  border-radius: 50%;
+  background: currentColor;
+  margin: -3.6px 0 0 -3.6px;
+}
+.lds-roller div:nth-child(1) {
+  animation-delay: -0.036s;
+}
+.lds-roller div:nth-child(1):after {
+  top: 62.62742px;
+  left: 62.62742px;
+}
+.lds-roller div:nth-child(2) {
+  animation-delay: -0.072s;
+}
+.lds-roller div:nth-child(2):after {
+  top: 67.71281px;
+  left: 56px;
+}
+.lds-roller div:nth-child(3) {
+  animation-delay: -0.108s;
+}
+.lds-roller div:nth-child(3):after {
+  top: 70.90963px;
+  left: 48.28221px;
+}
+.lds-roller div:nth-child(4) {
+  animation-delay: -0.144s;
+}
+.lds-roller div:nth-child(4):after {
+  top: 72px;
+  left: 40px;
+}
+.lds-roller div:nth-child(5) {
+  animation-delay: -0.18s;
+}
+.lds-roller div:nth-child(5):after {
+  top: 70.90963px;
+  left: 31.71779px;
+}
+.lds-roller div:nth-child(6) {
+  animation-delay: -0.216s;
+}
+.lds-roller div:nth-child(6):after {
+  top: 67.71281px;
+  left: 24px;
+}
+.lds-roller div:nth-child(7) {
+  animation-delay: -0.252s;
+}
+.lds-roller div:nth-child(7):after {
+  top: 62.62742px;
+  left: 17.37258px;
+}
+.lds-roller div:nth-child(8) {
+  animation-delay: -0.288s;
+}
+.lds-roller div:nth-child(8):after {
+  top: 56px;
+  left: 12.28719px;
+}
+@keyframes lds-roller {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/service-apply/src/components/common/Loader.tsx
+++ b/service-apply/src/components/common/Loader.tsx
@@ -1,0 +1,22 @@
+import './Loader.css';
+
+interface LoaderProps {
+  color?: string;
+}
+
+const Loader = ({ color = '#FFF' }: LoaderProps) => {
+  return (
+    <div className={`lds-roller text-[${color}]`}>
+      <div />
+      <div />
+      <div />
+      <div />
+      <div />
+      <div />
+      <div />
+      <div />
+    </div>
+  );
+};
+
+export default Loader;

--- a/service-apply/src/components/home/HomeLogin.tsx
+++ b/service-apply/src/components/home/HomeLogin.tsx
@@ -2,6 +2,8 @@ import { Button, InputText, Txt } from '@quokka/design-system';
 import { Link } from 'react-router-dom';
 import useLoginForm from '../../hooks/home/useLoginForm';
 import LoginInputBox from './LoginInputBox';
+import Loader from '../common/Loader';
+import LoginLoadText from './LoginLoadText';
 
 export const HomeLogin = () => {
   const {
@@ -12,6 +14,7 @@ export const HomeLogin = () => {
     onChangePassword,
     isError,
     errorMessage,
+    loginMutateStatus,
   } = useLoginForm();
 
   return (
@@ -38,12 +41,19 @@ export const HomeLogin = () => {
           <Link to="/password-reset">
             <Txt color="secondary">비밀번호 찾기</Txt>
           </Link>
-          <Button
-            type="submit"
-            className="py-4 px-14 rounded-lg max-sm:py-2 max-sm:px-8"
-          >
-            폼으로 이동
-          </Button>
+          {loginMutateStatus === 'pending' ? (
+            <div className="flex items-center gap-4">
+              <LoginLoadText>잠시만 기다려 주세요..</LoginLoadText>
+              <Loader color="#0255D5" />
+            </div>
+          ) : (
+            <Button
+              type="submit"
+              className="py-4 px-14 rounded-lg max-sm:py-2 max-sm:px-8"
+            >
+              폼으로 이동
+            </Button>
+          )}
           {isError && (
             <Txt size="sm" color="error">
               {errorMessage}

--- a/service-apply/src/components/home/HomeLogin.tsx
+++ b/service-apply/src/components/home/HomeLogin.tsx
@@ -1,58 +1,17 @@
 import { Button, InputText, Txt } from '@quokka/design-system';
-import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
-import { useLoginMutate } from '../../hooks/react-query/useUser';
-import { isEmail, isPassword } from '../../functions/validator';
+import { Link } from 'react-router-dom';
+import useLoginForm from '../../hooks/home/useLoginForm';
 
 export const HomeLogin = () => {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [isError, setIsError] = useState(false);
-  const [errorMessage, setErrorMessage] = useState('');
-
-  const { postLogin } = useLoginMutate();
-  const navigate = useNavigate();
-
-  const formAction = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    if (!email) {
-      alert('이메일을 입력해 주세요.');
-      return;
-    }
-    if (!password) {
-      alert('비밀번호를 입력해 주세요.');
-      return;
-    }
-    if (!isEmail(email)) {
-      alert('올바른 형식의 이메일을 입력해 주세요.');
-      setIsError(true);
-      setErrorMessage('올바른 형식의 이메일을 입력해 주세요.');
-      return;
-    }
-    if (!isPassword(password)) {
-      alert(
-        '비밀번호는 최소 8자 이상, 16자리 이하이며 최소 하나의 영문자, 숫자, 특수문자(!@#$%^&*)가 포함되어야 합니다.',
-      );
-      setIsError(true);
-      setErrorMessage(
-        '비밀번호는 최소 8자 이상, 16자리 이하이며 최소 하나의 영문자, 숫자, 특수문자(!@#$%^&*)가 포함되어야 합니다.',
-      );
-      return;
-    }
-    postLogin(
-      { email, pwd: password },
-      {
-        onError: (error) => {
-          alert(error.message);
-          setIsError(true);
-          setErrorMessage(error.message);
-        },
-        onSuccess: () => {
-          navigate('/apply');
-        },
-      },
-    );
-  };
+  const {
+    formAction,
+    email,
+    onChangeEmail,
+    password,
+    onChangePassword,
+    isError,
+    errorMessage,
+  } = useLoginForm();
 
   return (
     <div className="flex justify-end max-sm:mb-4">
@@ -69,10 +28,7 @@ export const HomeLogin = () => {
               name="email"
               className="w-full p-4"
               value={email}
-              onChange={(e) => {
-                setEmail(e.target.value);
-                setIsError(false);
-              }}
+              onChange={onChangeEmail}
             />
           </div>
           <div className="w-full">
@@ -83,10 +39,7 @@ export const HomeLogin = () => {
               name="password"
               className="w-full p-4"
               value={password}
-              onChange={(e) => {
-                setPassword(e.target.value);
-                setIsError(false);
-              }}
+              onChange={onChangePassword}
             />
           </div>
           <Link to={'/password-reset'}>

--- a/service-apply/src/components/home/HomeLogin.tsx
+++ b/service-apply/src/components/home/HomeLogin.tsx
@@ -89,7 +89,6 @@ export const HomeLogin = () => {
               }}
             />
           </div>
-          {isError && <Txt color="error">{errorMessage}</Txt>}
           <Link to={'/password-reset'}>
             <Txt color="secondary">비밀번호 찾기</Txt>
           </Link>
@@ -99,6 +98,11 @@ export const HomeLogin = () => {
           >
             폼으로 이동
           </Button>
+          {isError && (
+            <Txt size="sm" color="error">
+              {errorMessage}
+            </Txt>
+          )}
         </div>
       </form>
     </div>

--- a/service-apply/src/components/home/HomeLogin.tsx
+++ b/service-apply/src/components/home/HomeLogin.tsx
@@ -1,6 +1,7 @@
 import { Button, InputText, Txt } from '@quokka/design-system';
 import { Link } from 'react-router-dom';
 import useLoginForm from '../../hooks/home/useLoginForm';
+import LoginInputBox from './LoginInputBox';
 
 export const HomeLogin = () => {
   const {
@@ -20,29 +21,21 @@ export const HomeLogin = () => {
           신청 폼 작성하기
         </Txt>
         <div className="flex flex-col gap-3 items-end">
-          <div className="w-full">
-            <InputText
-              designType="box"
-              type="text"
-              placeholder="이메일"
-              name="email"
-              className="w-full p-4"
-              value={email}
-              onChange={onChangeEmail}
-            />
-          </div>
-          <div className="w-full">
-            <InputText
-              designType="box"
-              type="password"
-              placeholder="비밀번호"
-              name="password"
-              className="w-full p-4"
-              value={password}
-              onChange={onChangePassword}
-            />
-          </div>
-          <Link to={'/password-reset'}>
+          <LoginInputBox
+            type="text"
+            placeholder="이메일"
+            name="email"
+            value={email}
+            onChange={onChangeEmail}
+          />
+          <LoginInputBox
+            type="password"
+            placeholder="비밀번호"
+            name="password"
+            value={password}
+            onChange={onChangePassword}
+          />
+          <Link to="/password-reset">
             <Txt color="secondary">비밀번호 찾기</Txt>
           </Link>
           <Button

--- a/service-apply/src/components/home/LoginInputBox.tsx
+++ b/service-apply/src/components/home/LoginInputBox.tsx
@@ -1,0 +1,34 @@
+import { ChangeEvent } from 'react';
+import { InputText } from '../../../../design-system/src';
+
+interface LoginInputBoxProps {
+  placeholder: string;
+  value: string;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  type: 'text' | 'password'; // NOTE: If you need more types, add them here.
+  name: string;
+}
+
+const LoginInputBox = ({
+  placeholder,
+  value,
+  onChange,
+  type,
+  name,
+}: LoginInputBoxProps) => {
+  return (
+    <div className="w-full">
+      <InputText
+        designType="box"
+        type={type}
+        placeholder={placeholder}
+        name={name}
+        className="w-full p-4"
+        value={value}
+        onChange={onChange}
+      />
+    </div>
+  );
+};
+
+export default LoginInputBox;

--- a/service-apply/src/components/home/LoginLoadText.css
+++ b/service-apply/src/components/home/LoginLoadText.css
@@ -1,0 +1,9 @@
+@keyframes fdout {
+  to {
+    opacity: 0;
+  }
+}
+
+.loading-animation {
+  animation: fdout 1s linear infinite alternate;
+}

--- a/service-apply/src/components/home/LoginLoadText.tsx
+++ b/service-apply/src/components/home/LoginLoadText.tsx
@@ -1,0 +1,9 @@
+import { type PropsWithChildren } from 'react';
+import './LoginLoadText.css';
+
+interface LoginLoadTextProps extends PropsWithChildren {}
+const LoginLoadText = ({ children }: LoginLoadTextProps) => {
+  return <div className="font-bold loading-animation">{children}</div>;
+};
+
+export default LoginLoadText;

--- a/service-apply/src/hooks/apply/useApplyForm.tsx
+++ b/service-apply/src/hooks/apply/useApplyForm.tsx
@@ -86,6 +86,16 @@ export const useApplyForm = () => {
     setIsCaptchaModalOpen(true);
   };
 
+  const onCaptchaModalClose = () => {
+    setIsCaptchaModalOpen(false);
+  };
+
+  const onCaptchaModalSafeClose = () => {
+    if (window.confirm('창을 닫으면 신청을 취소합니다. 창을 닫으시겠습니까?')) {
+      setIsCaptchaModalOpen(false);
+    }
+  };
+
   return {
     sector,
     state,
@@ -94,8 +104,9 @@ export const useApplyForm = () => {
     isPrivacyModalOpen,
     setIsPrivacyModalOpen,
     isCaptchaModalOpen,
-    setIsCaptchaModalOpen,
     onCaptchaModalOpen,
+    onCaptchaModalClose,
+    onCaptchaModalSafeClose,
     isAgreed,
     setIsAgreed,
     isError,

--- a/service-apply/src/hooks/home/useLoginForm.ts
+++ b/service-apply/src/hooks/home/useLoginForm.ts
@@ -9,7 +9,7 @@ const useLoginForm = () => {
   const [isError, setIsError] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
 
-  const { postLogin, status } = useLoginMutate();
+  const { postLogin, status: loginMutateStatus } = useLoginMutate();
   const navigate = useNavigate();
 
   const formAction = (e: React.FormEvent<HTMLFormElement>) => {
@@ -71,6 +71,7 @@ const useLoginForm = () => {
     onChangePassword,
     isError,
     errorMessage,
+    loginMutateStatus,
   };
 };
 

--- a/service-apply/src/hooks/home/useLoginForm.ts
+++ b/service-apply/src/hooks/home/useLoginForm.ts
@@ -1,0 +1,77 @@
+import { ChangeEvent, useState } from 'react';
+import { useLoginMutate } from '../react-query/useUser';
+import { useNavigate } from 'react-router-dom';
+import { isEmail, isPassword } from '../../functions/validator';
+
+const useLoginForm = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [isError, setIsError] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const { postLogin, status } = useLoginMutate();
+  const navigate = useNavigate();
+
+  const formAction = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!email) {
+      alert('이메일을 입력해 주세요.');
+      return;
+    }
+    if (!password) {
+      alert('비밀번호를 입력해 주세요.');
+      return;
+    }
+    if (!isEmail(email)) {
+      alert('올바른 형식의 이메일을 입력해 주세요.');
+      setIsError(true);
+      setErrorMessage('올바른 형식의 이메일을 입력해 주세요.');
+      return;
+    }
+    if (!isPassword(password)) {
+      alert(
+        '비밀번호는 최소 8자 이상, 16자리 이하이며 최소 하나의 영문자, 숫자, 특수문자(!@#$%^&*)가 포함되어야 합니다.',
+      );
+      setIsError(true);
+      setErrorMessage(
+        '비밀번호는 최소 8자 이상, 16자리 이하이며 최소 하나의 영문자, 숫자, 특수문자(!@#$%^&*)가 포함되어야 합니다.',
+      );
+      return;
+    }
+    postLogin(
+      { email, pwd: password },
+      {
+        onError: (error) => {
+          alert(error.message);
+          setIsError(true);
+          setErrorMessage(error.message);
+        },
+        onSuccess: () => {
+          navigate('/apply');
+        },
+      },
+    );
+  };
+
+  const onChangeEmail = (e: ChangeEvent<HTMLInputElement>) => {
+    setEmail(e.target.value);
+    setIsError(false);
+  };
+
+  const onChangePassword = (e: ChangeEvent<HTMLInputElement>) => {
+    setPassword(e.target.value);
+    setIsError(false);
+  };
+
+  return {
+    formAction,
+    email,
+    onChangeEmail,
+    password,
+    onChangePassword,
+    isError,
+    errorMessage,
+  };
+};
+
+export default useLoginForm;

--- a/service-apply/src/hooks/react-query/useUser.tsx
+++ b/service-apply/src/hooks/react-query/useUser.tsx
@@ -15,7 +15,7 @@ import {
 import { setToken } from '../../functions/jwt';
 
 export const useLoginMutate = () => {
-  const { mutate } = useMutation({
+  const { mutate, status } = useMutation({
     mutationKey: ['login'],
     mutationFn: postLogin,
   });
@@ -37,6 +37,7 @@ export const useLoginMutate = () => {
         },
       });
     },
+    status,
   };
 };
 


### PR DESCRIPTION
## 주요 변경사항
- layout shift를 방지를 위한 로그인 에러 메시지 위치를 변경하였습니다.
- 신청폼의 applyModal의 loader를 변경하였습니다.
- 로그인 시 pending상태이면 로딩인디케이터를 보여줄 수 있도록 개선하였습니다.
- applyModal에서 의도치않은 바깥창 클릭시, 신청이 취소되는 문제를 해결하기 위해 방지하는 장치를 두었습니다.
  - 예시 동영상과 다르게 신청이 완료되면 unsafe한 close를 호출하므로 confirm창이 뜨지 않고 완료 페이지로 이동합니다.
- 신청폼에서 빠른 리팩터링을 위해 훅과 컴포넌트를 분리하고, 재사용할 수 있는 컴포넌트로 분리하였습니다.

https://github.com/user-attachments/assets/86e4d306-ec70-46f9-91e3-ea7786adcd09

https://github.com/user-attachments/assets/216ed5d6-6f65-46c6-a99d-5c6b69c19940

