### PR TITLE
refactor: usePeriodQuery에 retry 횟수를 매개변수로 추가

### DIFF
--- a/service-apply/src/components/apply/ApplyTitle.tsx
+++ b/service-apply/src/components/apply/ApplyTitle.tsx
@@ -26,7 +26,7 @@ export const ApplyTitle = () => {
 };
 
 const ApplyStartTime = () => {
-  const { startAt } = usePeriodQuery();
+  const { startAt } = usePeriodQuery({ retryNumber: 0 });
 
   return <Txt>{getApplyDateString(startAt)}</Txt>;
 };

--- a/service-apply/src/functions/error.ts
+++ b/service-apply/src/functions/error.ts
@@ -52,6 +52,7 @@ export type ERROR_CODE =
   | 'DECRYPTION_500_1'
   | 'ENCRYPTION_500_1'
   | 'NOTICE_404_1'
+  | 'Event_400_10'
   | 'EVENT_400_14'
   | 'EVENT_400_23';
 
@@ -96,6 +97,12 @@ export const getErrorContent = (error: ERROR_CODE): ERROR_TYPE => {
       return {
         type: 'ALERT_WITH_REDIRECT',
         content: '현재는 주차권 신청기간이 아닙니다.',
+        redirect: '/',
+      };
+    case 'Event_400_10':
+      return {
+        type: 'ALERT_WITH_REDIRECT',
+        content: '주차권 신청기간이 아닙니다.',
         redirect: '/',
       };
     case 'ENCRYPTION_500_1':

--- a/service-apply/src/hooks/react-query/usePeriodQuery.tsx
+++ b/service-apply/src/hooks/react-query/usePeriodQuery.tsx
@@ -1,12 +1,17 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { getRegistrationPeriod } from '../../apis/registration.apis';
 
-export const usePeriodQuery = () => {
+interface PeriodQueryParams {
+  retryNumber?: number;
+}
+
+export const usePeriodQuery = ({ retryNumber = 3 }: PeriodQueryParams = {}) => {
   const {
     data: { startAt, endAt, eventId },
   } = useSuspenseQuery({
     queryKey: ['period'],
     queryFn: getRegistrationPeriod,
+    retry: retryNumber,
   });
   return { startAt, endAt, eventId };
 };


### PR DESCRIPTION
## 주요 변경사항
usePeriodQuery 훅에 retry 횟수를 매개변수로 추가하였습니다.

## 리뷰어에게...
한 가지 걱정되는 부분은 해당 요청에 대해 실패 시 재 시도를 하지 않는 것입니다.
하지만 첫 요청 실패 시 아래와 같이 "신청 기간이 아닙니다." 라는 alert문을 띄우기 때문에 
alert문 뜬 후에 재 요청하여 응답이 성공하여 성공한 동작을 보여주는 것은 올바르지 않다고 생각합니다.
![image](https://github.com/user-attachments/assets/6d9001db-f9ad-4066-acee-1f8150b14999)

### alert 문이 4번 나오는 이유
usePeriodQuery 훅의 queryFn 요청이 실패 시 tanstack query에서 기본적으로 3번의 재 시도를 하기 때문입니다.

## 관련 이슈

closes #235 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정