### PR TITLE
fix: response가 ok가 아닌 경우 error response를 반환한다.

### DIFF
--- a/service-apply/src/functions/https.ts
+++ b/service-apply/src/functions/https.ts
@@ -17,18 +17,6 @@ const fetcher = async (url: string, req: RequestInit) => {
   const response = await fetch(BASE_URL + '/api' + url, {
     ...req,
     headers,
-  }).then((response) => {
-    if (!response.ok) {
-      return new ErrorResponse({
-        code: 'NETWORK_ERROR',
-        path: url,
-        reason: '네트워크 오류가 발생했습니다.',
-        status: 500,
-        success: false,
-        timeStamp: new Date().toISOString(),
-      });
-    }
-    return response;
   }).catch(() => {
     return new ErrorResponse({
       code: 'NETWORK_ERROR',
@@ -43,6 +31,18 @@ const fetcher = async (url: string, req: RequestInit) => {
   if (response instanceof ErrorResponse) {
     return response;
   }
+
+  if (response.status >= 500) {
+    return new ErrorResponse({
+      code: 'NETWORK_ERROR',
+      path: url,
+      reason: '네트워크 오류가 발생했습니다.',
+      status: 500,
+      success: false,
+      timeStamp: new Date().toISOString(),
+    });
+  }
+
   if (response.status >= 400) {
     return await errorStatusResult(response);
   }

--- a/service-apply/src/functions/https.ts
+++ b/service-apply/src/functions/https.ts
@@ -17,6 +17,18 @@ const fetcher = async (url: string, req: RequestInit) => {
   const response = await fetch(BASE_URL + '/api' + url, {
     ...req,
     headers,
+  }).then((response) => {
+    if (!response.ok) {
+      return new ErrorResponse({
+        code: 'NETWORK_ERROR',
+        path: url,
+        reason: '네트워크 오류가 발생했습니다.',
+        status: 500,
+        success: false,
+        timeStamp: new Date().toISOString(),
+      });
+    }
+    return response;
   }).catch(() => {
     return new ErrorResponse({
       code: 'NETWORK_ERROR',

--- a/service-manager/src/components/announcement/AnnouncementCreate.tsx
+++ b/service-manager/src/components/announcement/AnnouncementCreate.tsx
@@ -32,6 +32,11 @@ export const AnnouncementCreate = () => {
     });
   };
 
+  const onAddImageBlobHook = (blob: Blob, callback: (url: string) => void) => {
+    alert('이미지를 올릴 수 없습니다.');
+    return;
+  };
+
   return (
     <>
       <InputText
@@ -57,6 +62,9 @@ export const AnnouncementCreate = () => {
             placeholder="공지사항을 입력해주세요."
             previewHighlight={false}
             ref={editorRef}
+            hooks={{
+              addImageBlobHook: onAddImageBlobHook,
+            }}
           />
         </Suspense>
       </ErrorBoundary>

--- a/service-manager/src/components/announcement/AnnouncementUpdate.tsx
+++ b/service-manager/src/components/announcement/AnnouncementUpdate.tsx
@@ -37,6 +37,11 @@ export const AnnouncementUpdate = ({ announceId }: AnnouncementUpdateProps) => {
     });
   };
 
+  const onAddImageBlobHook = (blob: Blob, callback: (url: string) => void) => {
+    alert('이미지를 올릴 수 없습니다.');
+    return;
+  };
+
   return (
     <>
       <input
@@ -50,19 +55,20 @@ export const AnnouncementUpdate = ({ announceId }: AnnouncementUpdateProps) => {
         <Suspense>
           <ToastEditor
             initialValue={announceDetailData.announceContent}
-            toolbarItems={
-                [
-                  ['heading', 'bold', 'italic', 'strike'],
-                  ['hr', 'quote'],
-                  ['ul', 'ol', 'task', 'indent', 'outdent'],
-                  ['table', 'link'],
-                ]
-            }
+            toolbarItems={[
+              ['heading', 'bold', 'italic', 'strike'],
+              ['hr', 'quote'],
+              ['ul', 'ol', 'task', 'indent', 'outdent'],
+              ['table', 'link'],
+            ]}
             previewStyle="vertical"
             height="30rem"
             minHeight="calc(100vh - 33rem)"
             previewHighlight={false}
             ref={editorRef}
+            hooks={{
+              addImageBlobHook: onAddImageBlobHook,
+            }}
           />
         </Suspense>
       </ErrorBoundary>

--- a/service-manager/src/components/notice/NoticeUpdate.tsx
+++ b/service-manager/src/components/notice/NoticeUpdate.tsx
@@ -29,6 +29,11 @@ export const NoticeUpdate = () => {
     onUpdate({ noticeContent: markdown });
   };
 
+  const onAddImageBlobHook = (blob: Blob, callback: (url: string) => void) => {
+    alert('이미지를 올릴 수 없습니다.');
+    return;
+  };
+
   return (
     <div className="py-4">
       <ErrorBoundary>
@@ -47,6 +52,9 @@ export const NoticeUpdate = () => {
             initialEditType="markdown"
             previewHighlight={false}
             ref={editorRef}
+            hooks={{
+              addImageBlobHook: onAddImageBlobHook,
+            }}
           />
         </Suspense>
       </ErrorBoundary>

--- a/service-manager/src/functions/https.ts
+++ b/service-manager/src/functions/https.ts
@@ -19,18 +19,6 @@ const fetcher = async (url: string, req: RequestInit) => {
   const response = await fetch(BASE_URL + '/api' + url, {
     ...req,
     headers,
-  }).then((response) => {
-    if (!response.ok) {
-      return new ErrorResponse({
-        code: 'NETWORK_ERROR',
-        path: url,
-        reason: '네트워크 오류가 발생했습니다.',
-        status: 500,
-        success: false,
-        timeStamp: new Date().toISOString(),
-      });
-    }
-    return response;
   }).catch(() => {
     return new ErrorResponse({
       code: 'NETWORK_ERROR',
@@ -44,6 +32,17 @@ const fetcher = async (url: string, req: RequestInit) => {
 
   if (response instanceof ErrorResponse) {
     return response;
+  }
+
+  if (response.status >= 500) {
+    return new ErrorResponse({
+      code: 'NETWORK_ERROR',
+      path: url,
+      reason: '네트워크 오류가 발생했습니다.',
+      status: 500,
+      success: false,
+      timeStamp: new Date().toISOString(),
+    });
   }
 
   if (response.status >= 400) {

--- a/service-manager/src/functions/https.ts
+++ b/service-manager/src/functions/https.ts
@@ -19,6 +19,18 @@ const fetcher = async (url: string, req: RequestInit) => {
   const response = await fetch(BASE_URL + '/api' + url, {
     ...req,
     headers,
+  }).then((response) => {
+    if (!response.ok) {
+      return new ErrorResponse({
+        code: 'NETWORK_ERROR',
+        path: url,
+        reason: '네트워크 오류가 발생했습니다.',
+        status: 500,
+        success: false,
+        timeStamp: new Date().toISOString(),
+      });
+    }
+    return response;
   }).catch(() => {
     return new ErrorResponse({
       code: 'NETWORK_ERROR',


### PR DESCRIPTION
## 주요 변경사항

ok가 아닌 경우 error response를 반환하게 하였습니다.
ok인 경우에는 200~299의 http가 올 때입니다.
- https://developer.mozilla.org/en-US/docs/Web/API/Response/ok

추가적으로 editor에 어떠한 방법이든 이미지를 넣을려고 할 때 alert로  넣을 수 없다고 알려주고 업로드를 방지하였습니다.

<img width="1407" alt="스크린샷 2024-10-17 오후 11 38 16" src="https://github.com/user-attachments/assets/2cbff72b-ab7c-411a-935d-5da91d90978c">


## 리뷰어에게...

- 근본적인 사용자 방지도 추가하였습니다.

## 관련 이슈

- closes #240 

