### PR TITLE
fix: 잘못 정렬되고 있던 신청 현황 수정

### DIFF
--- a/service-manager/src/components/apply-list/ApplyList.tsx
+++ b/service-manager/src/components/apply-list/ApplyList.tsx
@@ -23,7 +23,6 @@ export const ApplyList = ({ eventId }: ApplyListProps) => {
           .filter(
             (registration) => registration.sectorNum === sector.sectorNumber,
           )
-          .sort((a, b) => (a.id < b.id ? -1 : 1))
           .map((registration, index) => ({
             구간: registration.sectorNum,
             순서: index + 1,

--- a/service-manager/src/hooks/react-query/useRegistration.tsx
+++ b/service-manager/src/hooks/react-query/useRegistration.tsx
@@ -6,5 +6,5 @@ export const useAllRegistrationQuery = (eventId: string) => {
     queryKey: ['allRegistration', eventId],
     queryFn: () => getAllRegistration(eventId),
   });
-  return { registrations: data.sort((a, b) => a.id - b.id) };
+  return { registrations: data };
 };


### PR DESCRIPTION
## 주요 변경사항
### 기존 문제 사항
백엔드에서 올바르게 보내주고 있던 신청 현황 목록을 프론트엔드에서 registrationId를 기준으로 정렬해서 문제가 생겼다.

- 백엔드 응답
1구간부터 5구간까지 순서대로 합격자, 예비 순으로 데이터를 보내주었다.

- 백엔드에서 정렬기준
합격자 : registrationId
예비 : 예비 순 (registrationId와는 관련없음)

### 변경 사항
엑셀 파일과 신청 현황 페이지에서 registrationId을 기준으로 정렬하는 코드를 삭제하였다.

### 올바르게 변경된 결과
- 백엔드 응답
<img width="300" src="https://github.com/user-attachments/assets/6e467a6f-baf8-4171-9710-7d416c2b9a85"/>

- 웹사이트 화면
![image](https://github.com/user-attachments/assets/1f5d7fe2-a839-4fe0-a16d-2e6352ddf6e3)

- 엑셀 화면
![image](https://github.com/user-attachments/assets/26637893-9520-47db-9cf8-5296f6630698)


## 관련 이슈

closes #261 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
