### PR TITLE
feat: 이벤트 생성 시간 방식 추가

### DIFF
--- a/service-manager/src/components/setting/SettingCreateTime.tsx
+++ b/service-manager/src/components/setting/SettingCreateTime.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, useState } from 'react';
+import { ChangeEvent, Dispatch, useState } from 'react';
 import DatePicker, { registerLocale, setDefaultLocale } from 'react-datepicker';
 import { Button, InputText, Txt } from '@quokka/design-system';
 import { ko } from 'date-fns/locale';
@@ -28,14 +28,75 @@ const DateTimePicker = ({ date, setDate, title }: SettingTimeProps) => {
   const selectedHour = date.getHours().toString().padStart(2, '0');
   const selectedMinute = date.getMinutes().toString().padStart(2, '0');
 
+  const onHourChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const newHour = e.target.value;
+
+    if (!/^\d*$/.test(newHour)) {
+      return alert('숫자만 입력 가능합니다.');
+    }
+
+    if (Number(newHour) > 23) {
+      return alert('유효한 시간이 아닙니다.');
+    }
+
+    if (newHour !== selectedHour) {
+      setDate(
+        new Date(
+          selectedYear,
+          Number(selectedMonth) - 1,
+          Number(selectedDay),
+          Number(newHour),
+          Number(selectedMinute),
+        ),
+      );
+    }
+  };
+
+  const onMinuteChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const newMinute = e.target.value;
+
+    if (!/^\d*$/.test(newMinute)) {
+      return alert('숫자만 입력 가능합니다.');
+    }
+
+    if (Number(newMinute) > 59) {
+      return alert('유효한 시간이 아닙니다.');
+    }
+
+    if (newMinute !== selectedMinute) {
+      setDate(
+        new Date(
+          selectedYear,
+          Number(selectedMonth) - 1,
+          Number(selectedDay),
+          Number(selectedHour),
+          Number(newMinute),
+        ),
+      );
+    }
+  };
+
   return (
     <div className="flex flex-col gap-4 flex-1 min-w-[25rem]">
       <Txt size="h3">{title}</Txt>
-      <Txt
-        size="h4"
-        color="white"
-        className="text-center p-4 bg-[linear-gradient(91deg,#0255D5_12.84%,#9CBBFF_104.56%)] rounded-md"
-      >{`${selectedYear} : ${selectedMonth} : ${selectedDay} / ${selectedHour} : ${selectedMinute}`}</Txt>
+      <div className="text-center p-4 bg-[linear-gradient(91deg,#0255D5_12.84%,#9CBBFF_104.56%)] rounded-md">
+        <Txt size="h4" color="white">
+          {`${selectedYear} : ${selectedMonth} : ${selectedDay} / `}
+        </Txt>
+        <input
+          className="text-2xl font-semibold w-7 text-white bg-transparent"
+          value={selectedHour}
+          onChange={onHourChange}
+        />
+        <Txt size="h4" color="white">
+          {`${' : '}`}
+        </Txt>
+        <input
+          className="text-2xl font-semibold w-7 text-white bg-transparent"
+          value={selectedMinute}
+          onChange={onMinuteChange}
+        />
+      </div>
       <div className="flex justify-center">
         <DatePicker
           selected={date}

--- a/service-manager/src/components/setting/SettingCreateTime.tsx
+++ b/service-manager/src/components/setting/SettingCreateTime.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, Dispatch, useState } from 'react';
+import { ChangeEvent, Dispatch, useState, type SetStateAction } from 'react';
 import DatePicker, { registerLocale, setDefaultLocale } from 'react-datepicker';
 import { Button, InputText, Txt } from '@quokka/design-system';
 import { ko } from 'date-fns/locale';
@@ -7,7 +7,6 @@ import 'react-datepicker/dist/react-datepicker.css';
 import './DateTime.css';
 import { useSectionTimeSettingCreate } from '../../hooks/react-query/useSectionTimeSetting';
 import { getFormalDateBy, isPastTime } from '../../functions/date';
-import { SetStateAction } from 'jotai';
 import { isNumber } from '../../functions/validator';
 
 registerLocale('ko', ko);

--- a/service-manager/src/components/setting/SettingCreateTime.tsx
+++ b/service-manager/src/components/setting/SettingCreateTime.tsx
@@ -6,8 +6,11 @@ import { ko } from 'date-fns/locale';
 import 'react-datepicker/dist/react-datepicker.css';
 import './DateTime.css';
 import { useSectionTimeSettingCreate } from '../../hooks/react-query/useSectionTimeSetting';
-import { getFormalDateBy, isValidateTime } from '../../functions/date';
-import { isNumber } from '../../functions/validator';
+import {
+  getFormalDateBy,
+  isValidateTime,
+  isValidTime,
+} from '../../functions/date';
 
 registerLocale('ko', ko);
 setDefaultLocale('ko');
@@ -31,7 +34,7 @@ const DateTimePicker = ({ date, setDate, title }: SettingTimeProps) => {
   const onHourChange = (e: ChangeEvent<HTMLInputElement>) => {
     const newHour = e.target.value;
 
-    if (!isNumber(newHour)) {
+    if (!isValidTime(newHour)) {
       return alert('숫자만 입력 가능합니다.');
     }
 
@@ -55,7 +58,7 @@ const DateTimePicker = ({ date, setDate, title }: SettingTimeProps) => {
   const onMinuteChange = (e: ChangeEvent<HTMLInputElement>) => {
     const newMinute = e.target.value;
 
-    if (!isNumber(newMinute)) {
+    if (!isValidTime(newMinute)) {
       return alert('숫자만 입력 가능합니다.');
     }
 

--- a/service-manager/src/components/setting/SettingCreateTime.tsx
+++ b/service-manager/src/components/setting/SettingCreateTime.tsx
@@ -8,6 +8,7 @@ import './DateTime.css';
 import { useSectionTimeSettingCreate } from '../../hooks/react-query/useSectionTimeSetting';
 import { getFormalDateBy, isPastTime } from '../../functions/date';
 import { SetStateAction } from 'jotai';
+import { isNumber } from '../../functions/validator';
 
 registerLocale('ko', ko);
 setDefaultLocale('ko');
@@ -31,7 +32,7 @@ const DateTimePicker = ({ date, setDate, title }: SettingTimeProps) => {
   const onHourChange = (e: ChangeEvent<HTMLInputElement>) => {
     const newHour = e.target.value;
 
-    if (!/^\d*$/.test(newHour)) {
+    if (!isNumber(newHour)) {
       return alert('숫자만 입력 가능합니다.');
     }
 

--- a/service-manager/src/components/setting/SettingCreateTime.tsx
+++ b/service-manager/src/components/setting/SettingCreateTime.tsx
@@ -6,7 +6,7 @@ import { ko } from 'date-fns/locale';
 import 'react-datepicker/dist/react-datepicker.css';
 import './DateTime.css';
 import { useSectionTimeSettingCreate } from '../../hooks/react-query/useSectionTimeSetting';
-import { getFormalDateBy, isPastTime } from '../../functions/date';
+import { getFormalDateBy, isValidateTime } from '../../functions/date';
 import { isNumber } from '../../functions/validator';
 
 registerLocale('ko', ko);
@@ -122,15 +122,7 @@ export const SettingCreateTime = () => {
       return;
     }
 
-    if (isPastTime(openDate)) {
-      alert('OPEN 시간을 현재 시간보다 이전 시간으로 설정할 수 없습니다.');
-      return;
-    }
-
-    if (isPastTime(endDate)) {
-      alert('CLOSE 시간을 현재 시간보다 이전 시간으로 설정할 수 없습니다.');
-      return;
-    }
+    if (!isValidateTime(openDate, endDate)) return;
 
     createSettingTime({
       startAt: openDate,

--- a/service-manager/src/components/setting/SettingCreateTime.tsx
+++ b/service-manager/src/components/setting/SettingCreateTime.tsx
@@ -140,18 +140,9 @@ export const SettingCreateTime = () => {
   };
 
   const onSetCreateTime =
-    (
-      predicate: (date: Date) => boolean,
-      errMsg: string,
-      setDate: Dispatch<SetStateAction<Date>>,
-      setDateType: 'open' | 'close',
-    ) =>
+    (setDate: Dispatch<SetStateAction<Date>>, setDateType: 'open' | 'close') =>
     (date: Date | null) => {
       if (!date) return;
-      if (predicate(date)) {
-        alert(errMsg);
-        return;
-      }
       setDate(date);
       if (setDateType === 'open' && date > endDate) {
         setEndDate(date);
@@ -173,22 +164,12 @@ export const SettingCreateTime = () => {
       <div className="flex justify-around gap-8">
         <DateTimePicker
           date={openDate}
-          setDate={onSetCreateTime(
-            isPastTime,
-            '현재 시간보다 이전 시간으로 설정할 수 없습니다.',
-            setOpenDate,
-            'open',
-          )}
+          setDate={onSetCreateTime(setOpenDate, 'open')}
           title="Open"
         />
         <DateTimePicker
           date={endDate}
-          setDate={onSetCreateTime(
-            isPastTime,
-            '현재 시간보다 이전 시간으로 설정할 수 없습니다.',
-            setEndDate,
-            'close',
-          )}
+          setDate={onSetCreateTime(setEndDate, 'close')}
           title="Close"
         />
       </div>

--- a/service-manager/src/components/setting/SettingCreateTime.tsx
+++ b/service-manager/src/components/setting/SettingCreateTime.tsx
@@ -56,7 +56,7 @@ const DateTimePicker = ({ date, setDate, title }: SettingTimeProps) => {
   const onMinuteChange = (e: ChangeEvent<HTMLInputElement>) => {
     const newMinute = e.target.value;
 
-    if (!/^\d*$/.test(newMinute)) {
+    if (!isNumber(newMinute)) {
       return alert('숫자만 입력 가능합니다.');
     }
 

--- a/service-manager/src/components/setting/SettingCreateTime.tsx
+++ b/service-manager/src/components/setting/SettingCreateTime.tsx
@@ -8,7 +8,7 @@ import './DateTime.css';
 import { useSectionTimeSettingCreate } from '../../hooks/react-query/useSectionTimeSetting';
 import {
   getFormalDateBy,
-  isValidateTime,
+  isValidDate,
   isValidTime,
 } from '../../functions/date';
 
@@ -125,7 +125,7 @@ export const SettingCreateTime = () => {
       return;
     }
 
-    if (!isValidateTime(openDate, endDate)) return;
+    if (!isValidDate(openDate, endDate)) return;
 
     createSettingTime({
       startAt: openDate,

--- a/service-manager/src/components/setting/SettingCreateTime.tsx
+++ b/service-manager/src/components/setting/SettingCreateTime.tsx
@@ -88,8 +88,8 @@ const DateTimePicker = ({ date, setDate, title }: SettingTimeProps) => {
           value={selectedHour}
           onChange={onHourChange}
         />
-        <Txt size="h4" color="white">
-          {`${' : '}`}
+        <Txt size="h4" color="white" className="pl-2 pr-2">
+          :
         </Txt>
         <input
           className="text-2xl font-semibold w-7 text-white bg-transparent"

--- a/service-manager/src/components/setting/SettingTime.tsx
+++ b/service-manager/src/components/setting/SettingTime.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 import DatePicker, { registerLocale, setDefaultLocale } from 'react-datepicker';
 import { Button, InputText, Txt } from '@quokka/design-system';
 import { ko } from 'date-fns/locale';
@@ -33,14 +33,75 @@ const DateTimePicker = ({ date, setDate, title }: SettingTimeProps) => {
   const selectedHour = date.getHours().toString().padStart(2, '0');
   const selectedMinute = date.getMinutes().toString().padStart(2, '0');
 
+  const onHourChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const newHour = e.target.value;
+
+    if (!/^\d*$/.test(newHour)) {
+      return alert('숫자만 입력 가능합니다.');
+    }
+
+    if (Number(newHour) > 23) {
+      return alert('유효한 시간이 아닙니다.');
+    }
+
+    if (newHour !== selectedHour) {
+      setDate(
+        new Date(
+          selectedYear,
+          Number(selectedMonth) - 1,
+          Number(selectedDay),
+          Number(newHour),
+          Number(selectedMinute),
+        ),
+      );
+    }
+  };
+
+  const onMinuteChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const newMinute = e.target.value;
+
+    if (!/^\d*$/.test(newMinute)) {
+      return alert('숫자만 입력 가능합니다.');
+    }
+
+    if (Number(newMinute) > 59) {
+      return alert('유효한 시간이 아닙니다.');
+    }
+
+    if (newMinute !== selectedMinute) {
+      setDate(
+        new Date(
+          selectedYear,
+          Number(selectedMonth) - 1,
+          Number(selectedDay),
+          Number(selectedHour),
+          Number(newMinute),
+        ),
+      );
+    }
+  };
+
   return (
     <div className="flex flex-col gap-4 flex-1 min-w-[25rem]">
       <Txt size="h3">{title}</Txt>
-      <Txt
-        size="h4"
-        color="white"
-        className="text-center p-4 bg-[linear-gradient(91deg,#0255D5_12.84%,#9CBBFF_104.56%)] rounded-md"
-      >{`${selectedYear} : ${selectedMonth} : ${selectedDay} / ${selectedHour} : ${selectedMinute}`}</Txt>
+      <div className="text-center p-4 bg-[linear-gradient(91deg,#0255D5_12.84%,#9CBBFF_104.56%)] rounded-md">
+        <Txt size="h4" color="white">
+          {`${selectedYear} : ${selectedMonth} : ${selectedDay} / `}
+        </Txt>
+        <input
+          className="text-2xl font-semibold w-7 text-white bg-transparent"
+          value={selectedHour}
+          onChange={onHourChange}
+        />
+        <Txt size="h4" color="white">
+          {`${' : '}`}
+        </Txt>
+        <input
+          className="text-2xl font-semibold w-7 text-white bg-transparent"
+          value={selectedMinute}
+          onChange={onMinuteChange}
+        />
+      </div>
       <div className="flex justify-center">
         <DatePicker
           selected={date}

--- a/service-manager/src/components/setting/SettingTime.tsx
+++ b/service-manager/src/components/setting/SettingTime.tsx
@@ -94,8 +94,8 @@ const DateTimePicker = ({ date, setDate, title }: SettingTimeProps) => {
           value={selectedHour}
           onChange={onHourChange}
         />
-        <Txt size="h4" color="white">
-          {`${' : '}`}
+        <Txt size="h4" color="white" className="pl-2 pr-2">
+          :
         </Txt>
         <input
           className="text-2xl font-semibold w-7 text-white bg-transparent"

--- a/service-manager/src/components/setting/SettingTime.tsx
+++ b/service-manager/src/components/setting/SettingTime.tsx
@@ -199,8 +199,6 @@ export const SettingTime = ({ eventId }: { eventId: string }) => {
           setDate={(date) => {
             if (event.eventStatus === 'CLOSED') return;
             if (!date) return;
-            if (date < openDate)
-              return alert('Open 시간 이전 시간으로 설정할 수 없습니다.');
             setEndDate(date);
           }}
           title="Close"

--- a/service-manager/src/components/setting/SettingTime.tsx
+++ b/service-manager/src/components/setting/SettingTime.tsx
@@ -13,6 +13,7 @@ import {
   useSettingPublishQueryBy,
 } from '../../hooks/react-query/useSetting';
 import { isPastTime } from '../../functions/date';
+import { isNumber } from '../../functions/validator';
 
 registerLocale('ko', ko);
 setDefaultLocale('ko');
@@ -36,7 +37,7 @@ const DateTimePicker = ({ date, setDate, title }: SettingTimeProps) => {
   const onHourChange = (e: ChangeEvent<HTMLInputElement>) => {
     const newHour = e.target.value;
 
-    if (!/^\d*$/.test(newHour)) {
+    if (!isNumber(newHour)) {
       return alert('숫자만 입력 가능합니다.');
     }
 

--- a/service-manager/src/components/setting/SettingTime.tsx
+++ b/service-manager/src/components/setting/SettingTime.tsx
@@ -188,10 +188,6 @@ export const SettingTime = ({ eventId }: { eventId: string }) => {
           setDate={(date) => {
             if (event.eventStatus === 'CLOSED') return;
             if (!date) return;
-            if (isPastTime(date)) {
-              alert('현재 시간보다 이전 시간으로 설정할 수 없습니다.');
-              return;
-            }
             setOpenDate(date);
             if (date > endDate) setEndDate(date);
           }}
@@ -202,11 +198,8 @@ export const SettingTime = ({ eventId }: { eventId: string }) => {
           setDate={(date) => {
             if (event.eventStatus === 'CLOSED') return;
             if (!date) return;
-            if (date < openDate) return;
-            if (isPastTime(date)) {
-              alert('현재 시간보다 이전 시간으로 설정할 수 없습니다.');
-              return;
-            }
+            if (date < openDate)
+              return alert('Open 시간 이전 시간으로 설정할 수 없습니다.');
             setEndDate(date);
           }}
           title="Close"
@@ -221,6 +214,21 @@ export const SettingTime = ({ eventId }: { eventId: string }) => {
               alert('제목을 입력해주세요.');
               return;
             }
+
+            if (isPastTime(openDate)) {
+              alert(
+                'OPEN 시간을 현재 시간보다 이전 시간으로 설정할 수 없습니다.',
+              );
+              return;
+            }
+
+            if (isPastTime(endDate)) {
+              alert(
+                'CLOSE 시간을 현재 시간보다 이전 시간으로 설정할 수 없습니다.',
+              );
+              return;
+            }
+
             updateSettingTime({
               startAt: openDate,
               endAt: endDate,

--- a/service-manager/src/components/setting/SettingTime.tsx
+++ b/service-manager/src/components/setting/SettingTime.tsx
@@ -12,7 +12,7 @@ import {
   useSettingPublishMutateBy,
   useSettingPublishQueryBy,
 } from '../../hooks/react-query/useSetting';
-import { isValidateTime, isValidTime } from '../../functions/date';
+import { isValidDate, isValidTime } from '../../functions/date';
 
 registerLocale('ko', ko);
 setDefaultLocale('ko');
@@ -215,7 +215,7 @@ export const SettingTime = ({ eventId }: { eventId: string }) => {
               return;
             }
 
-            if (!isValidateTime(openDate, endDate)) return;
+            if (!isValidDate(openDate, endDate)) return;
 
             updateSettingTime({
               startAt: openDate,

--- a/service-manager/src/components/setting/SettingTime.tsx
+++ b/service-manager/src/components/setting/SettingTime.tsx
@@ -61,7 +61,7 @@ const DateTimePicker = ({ date, setDate, title }: SettingTimeProps) => {
   const onMinuteChange = (e: ChangeEvent<HTMLInputElement>) => {
     const newMinute = e.target.value;
 
-    if (!/^\d*$/.test(newMinute)) {
+    if (!isNumber(newMinute)) {
       return alert('숫자만 입력 가능합니다.');
     }
 

--- a/service-manager/src/components/setting/SettingTime.tsx
+++ b/service-manager/src/components/setting/SettingTime.tsx
@@ -187,7 +187,8 @@ export const SettingTime = ({ eventId }: { eventId: string }) => {
         <DateTimePicker
           date={openDate}
           setDate={(date) => {
-            if (event.eventStatus === 'CLOSED') return;
+            if (event.eventStatus === 'CLOSED')
+              return alert('종료된 이벤트는 수정할 수 없습니다.');
             if (!date) return;
             setOpenDate(date);
             if (date > endDate) setEndDate(date);
@@ -197,7 +198,8 @@ export const SettingTime = ({ eventId }: { eventId: string }) => {
         <DateTimePicker
           date={endDate}
           setDate={(date) => {
-            if (event.eventStatus === 'CLOSED') return;
+            if (event.eventStatus === 'CLOSED')
+              return alert('종료된 이벤트는 수정할 수 없습니다.');
             if (!date) return;
             setEndDate(date);
           }}

--- a/service-manager/src/components/setting/SettingTime.tsx
+++ b/service-manager/src/components/setting/SettingTime.tsx
@@ -12,7 +12,7 @@ import {
   useSettingPublishMutateBy,
   useSettingPublishQueryBy,
 } from '../../hooks/react-query/useSetting';
-import { isPastTime } from '../../functions/date';
+import { isValidateTime } from '../../functions/date';
 import { isNumber } from '../../functions/validator';
 
 registerLocale('ko', ko);
@@ -216,19 +216,7 @@ export const SettingTime = ({ eventId }: { eventId: string }) => {
               return;
             }
 
-            if (isPastTime(openDate)) {
-              alert(
-                'OPEN 시간을 현재 시간보다 이전 시간으로 설정할 수 없습니다.',
-              );
-              return;
-            }
-
-            if (isPastTime(endDate)) {
-              alert(
-                'CLOSE 시간을 현재 시간보다 이전 시간으로 설정할 수 없습니다.',
-              );
-              return;
-            }
+            if (!isValidateTime(openDate, endDate)) return;
 
             updateSettingTime({
               startAt: openDate,

--- a/service-manager/src/components/setting/SettingTime.tsx
+++ b/service-manager/src/components/setting/SettingTime.tsx
@@ -12,8 +12,7 @@ import {
   useSettingPublishMutateBy,
   useSettingPublishQueryBy,
 } from '../../hooks/react-query/useSetting';
-import { isValidateTime } from '../../functions/date';
-import { isNumber } from '../../functions/validator';
+import { isValidateTime, isValidTime } from '../../functions/date';
 
 registerLocale('ko', ko);
 setDefaultLocale('ko');
@@ -37,7 +36,7 @@ const DateTimePicker = ({ date, setDate, title }: SettingTimeProps) => {
   const onHourChange = (e: ChangeEvent<HTMLInputElement>) => {
     const newHour = e.target.value;
 
-    if (!isNumber(newHour)) {
+    if (!isValidTime(newHour)) {
       return alert('숫자만 입력 가능합니다.');
     }
 
@@ -61,7 +60,7 @@ const DateTimePicker = ({ date, setDate, title }: SettingTimeProps) => {
   const onMinuteChange = (e: ChangeEvent<HTMLInputElement>) => {
     const newMinute = e.target.value;
 
-    if (!isNumber(newMinute)) {
+    if (!isValidTime(newMinute)) {
       return alert('숫자만 입력 가능합니다.');
     }
 

--- a/service-manager/src/functions/date.ts
+++ b/service-manager/src/functions/date.ts
@@ -22,7 +22,7 @@ export const isPastTime = (date: Date) => {
   return Date.now() > date.getTime();
 };
 
-export const isValidateTime = (openDate: Date, endDate: Date) => {
+export const isValidDate = (openDate: Date, endDate: Date) => {
   if (isPastTime(openDate)) {
     alert('OPEN 시간을 현재 시간보다 이후로 설정해야 합니다.');
     return false;

--- a/service-manager/src/functions/date.ts
+++ b/service-manager/src/functions/date.ts
@@ -21,3 +21,22 @@ export const getFormalDateBy = (time: Date) => {
 export const isPastTime = (date: Date) => {
   return Date.now() > date.getTime();
 };
+
+export const isValidateTime = (openDate: Date, endDate: Date) => {
+  if (isPastTime(openDate)) {
+    alert('OPEN 시간을 현재 시간보다 이후로 설정해야 합니다.');
+    return false;
+  }
+
+  if (isPastTime(endDate)) {
+    alert('CLOSE 시간을 현재 시간보다 이후로 설정해야 합니다.');
+    return false;
+  }
+
+  if (openDate >= endDate) {
+    alert('CLOSE 시간을 OPEN 시간보다 이후로 설정해야 합니다.');
+    return false;
+  }
+
+  return true;
+};

--- a/service-manager/src/functions/date.ts
+++ b/service-manager/src/functions/date.ts
@@ -40,3 +40,7 @@ export const isValidateTime = (openDate: Date, endDate: Date) => {
 
   return true;
 };
+
+export const isValidTime = (time: string) => {
+  return !isNaN(Number(time));
+};

--- a/service-manager/src/functions/validator.ts
+++ b/service-manager/src/functions/validator.ts
@@ -12,3 +12,5 @@ export const isPassword = (password: string) =>
   /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*])[a-zA-Z\d!@#$%^&*]{8,16}$/.test(
     password,
   );
+
+export const isNumber = (time: string) => /^\d*$/.test(time);

--- a/service-manager/src/functions/validator.ts
+++ b/service-manager/src/functions/validator.ts
@@ -12,5 +12,3 @@ export const isPassword = (password: string) =>
   /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*])[a-zA-Z\d!@#$%^&*]{8,16}$/.test(
     password,
   );
-
-export const isNumber = (time: string) => /^\d*$/.test(time);


### PR DESCRIPTION
## 주요 변경사항
### 기존 UI
<image src="https://github.com/user-attachments/assets/7e17b838-800d-471e-a7b3-88eef9975435" width="700"/>

30분 단위로만 이벤트를 설정할 수 있었습니다.

### 변경된 방식
![image](https://github.com/user-attachments/assets/5cb700ed-756c-4be2-b7c8-fd986a741760)
시간과 분에 마우스를 클릭하면 focus가 되면서 키보드로 숫자를 입력할 수 있습니다.

- validation 위치 변경
현재 시간보다 이전 시간으로 시간을 설정하지 못하게 하는 로직을 이벤트를 수정할 때와 저장할 때 수행하도록 하였습니다.
## 관련 이슈

closes #265 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
