### PR TITLE
fix: 잘못된 invalidateQueries의 위치 변경

### DIFF
--- a/service-manager/src/hooks/react-query/useAnnounce.tsx
+++ b/service-manager/src/hooks/react-query/useAnnounce.tsx
@@ -81,7 +81,6 @@ export const useAnnounceUpdateMutate = () => {
 };
 
 export const useAnnounceDeleteMutate = () => {
-  const queryClient = useQueryClient();
   const { mutate } = useMutation({
     mutationKey: ['announceDelete'],
     mutationFn: deleteAnnounceById,
@@ -99,9 +98,6 @@ export const useAnnounceDeleteMutate = () => {
         ...mutateOption,
         onSettled: (data) => {
           if (!data) throw new Error('data is undefined');
-          queryClient.invalidateQueries({
-            queryKey: ['announceList'],
-          });
         },
       });
     },

--- a/service-manager/src/hooks/react-query/useAnnounceForm.tsx
+++ b/service-manager/src/hooks/react-query/useAnnounceForm.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query';
 import {
   useAnnounceCreateMutate,
   useAnnounceDeleteMutate,
@@ -88,6 +89,7 @@ export const useAnnounceUpdate = () => {
 export const useAnnounceDelete = () => {
   const { deleteAnnounceById } = useAnnounceDeleteMutate();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const onDelete = (announceId: number) => {
     deleteAnnounceById(announceId, {
@@ -96,6 +98,9 @@ export const useAnnounceDelete = () => {
       },
       onSuccess: (data) => {
         if (!data) throw new Error('data is undefined');
+        queryClient.invalidateQueries({
+          queryKey: ['announceList'],
+        });
         alert('삭제되었습니다.');
         navigate('/announcement');
       },


### PR DESCRIPTION
## 주요 변경사항
공지 사항 삭제 시 invalidateQueries 로직을 onSettled에서 onSuccess로 이동시켰습니다. (onSettled는 api 요청이 성공이든 실패이든 항상 수행되기 때문에 성공 시에 invalidateQueries 하는게 맞다고 판단하였습니다.)

## 관련 이슈

closes #246 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
