### PR TITLE
feat: 경차가 아닌 학생의 수 표시

### DIFF
--- a/service-manager/src/components/apply-list/ApplyCount.tsx
+++ b/service-manager/src/components/apply-list/ApplyCount.tsx
@@ -13,9 +13,13 @@ interface ApplyCountProps {
 export const ApplyCount = ({ eventId, sector }: ApplyCountProps) => {
   const { sectorSettingData } = useSectorQueryById(eventId);
   const { registrations } = useAllRegistrationQuery(eventId);
-  const applicantNumber =
-    registrations?.filter((data) => data.sectorNum === sector) ?? 0;
-  const limit = sectorSettingData?.find((data) => data.sectorNumber === sector);
+  const applicantNumber = registrations.filter(
+    (data) => data.sectorNum === sector,
+  );
+  const limit = sectorSettingData.find((data) => data.sectorNumber === sector);
+  const noCompactNumber = registrations.filter(
+    (data) => !data.isCompact,
+  ).length;
 
   return (
     <div className="flex flex-col gap-2">
@@ -30,6 +34,9 @@ export const ApplyCount = ({ eventId, sector }: ApplyCountProps) => {
           applicantNumber.length - (limit?.sectorCapacity ?? 0),
           0,
         )}명 / ${limit?.reserve ?? 0}명`}
+      </Txt>
+      <Txt size="h6" color="black">
+        {`경차 아닌 학생 정원: ${noCompactNumber}명 / ${registrations.length}명`}
       </Txt>
     </div>
   );

--- a/service-manager/src/components/apply-list/ApplyCount.tsx
+++ b/service-manager/src/components/apply-list/ApplyCount.tsx
@@ -13,11 +13,12 @@ interface ApplyCountProps {
 export const ApplyCount = ({ eventId, sector }: ApplyCountProps) => {
   const { sectorSettingData } = useSectorQueryById(eventId);
   const { registrations } = useAllRegistrationQuery(eventId);
-  const applicantNumber = registrations.filter(
-    (data) => data.sectorNum === sector,
-  );
-  const limit = sectorSettingData.find((data) => data.sectorNumber === sector);
-  const noCompactCount = registrations.filter((data) => !data.isCompact).length;
+
+  const applicantNumber =
+    registrations?.filter((data) => data.sectorNum === sector) ?? [];
+  const limit = sectorSettingData?.find((data) => data.sectorNumber === sector);
+  const noCompactCount = registrations?.filter((data) => !data.isCompact)
+    .length;
 
   return (
     <div className="flex flex-col gap-2">

--- a/service-manager/src/components/apply-list/ApplyCount.tsx
+++ b/service-manager/src/components/apply-list/ApplyCount.tsx
@@ -17,9 +17,7 @@ export const ApplyCount = ({ eventId, sector }: ApplyCountProps) => {
     (data) => data.sectorNum === sector,
   );
   const limit = sectorSettingData.find((data) => data.sectorNumber === sector);
-  const noCompactNumber = registrations.filter(
-    (data) => !data.isCompact,
-  ).length;
+  const noCompactCount = registrations.filter((data) => !data.isCompact).length;
 
   return (
     <div className="flex flex-col gap-2">
@@ -36,7 +34,7 @@ export const ApplyCount = ({ eventId, sector }: ApplyCountProps) => {
         )}명 / ${limit?.reserve ?? 0}명`}
       </Txt>
       <Txt size="h6" color="black">
-        {`경차 아닌 학생 정원: ${noCompactNumber}명 / ${registrations.length}명`}
+        {`경차 아닌 학생 정원: ${noCompactCount}명 / ${registrations.length}명`}
       </Txt>
     </div>
   );

--- a/service-manager/src/components/apply-list/ApplyList.tsx
+++ b/service-manager/src/components/apply-list/ApplyList.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { Suspense, useState } from 'react';
 import { Button } from '@quokka/design-system';
 
 import {
@@ -7,6 +7,7 @@ import {
 } from '../../hooks/react-query/useRegistration';
 import { useSectorQueryById } from '../../hooks/react-query/useSetting';
 import { ApplyCount } from './ApplyCount';
+import ErrorBoundary from '../common/ErrorBoundary';
 
 interface ApplyListProps {
   eventId: string;
@@ -67,7 +68,11 @@ export const ApplyList = ({ eventId }: ApplyListProps) => {
       </div>
       <div className="w-full">
         <div className="flex justify-between align-bottom">
-          <ApplyCount eventId={eventId} sector={selectedSector} />
+          <ErrorBoundary>
+            <Suspense>
+              <ApplyCount eventId={eventId} sector={selectedSector} />
+            </Suspense>
+          </ErrorBoundary>
           <div className="text-right my-5">
             <Button
               size="small"

--- a/service-manager/src/components/apply-list/ApplyList.tsx
+++ b/service-manager/src/components/apply-list/ApplyList.tsx
@@ -82,6 +82,7 @@ export const ApplyList = ({ eventId }: ApplyListProps) => {
             </Button>
           </div>
         </div>
+        <div className="mb-4" />
         <table className="w-full min-w-[50rem]">
           <thead>
             <tr>

--- a/service-manager/src/pages/apply/ApplyList.page.tsx
+++ b/service-manager/src/pages/apply/ApplyList.page.tsx
@@ -1,9 +1,17 @@
 import { useParams } from 'react-router-dom';
 import { ApplyList } from '../../components/apply-list/ApplyList';
+import ErrorBoundary from '../../components/common/ErrorBoundary';
+import { Suspense } from 'react';
 
 export const ApplyListPage = () => {
   const { eventId } = useParams();
   if (!eventId) return <div>잘못된 접근입니다.</div>;
 
-  return <ApplyList eventId={eventId} />;
+  return (
+    <ErrorBoundary>
+      <Suspense>
+        <ApplyList eventId={eventId} />
+      </Suspense>
+    </ErrorBoundary>
+  );
 };


### PR DESCRIPTION
## 주요 변경사항

- 경차가 아닌 학생의 수 표시
- 옵셔널 체이닝 제거

## 리뷰어에게...

총학생회의 요구사항으로 경차가 아닌 학생의 수를 표시하였습니다.
get api 요청에 대해서 useSuspenseQuery를 사용하고 있기 때문에 registrations와 sectorSettingData에 대한 로직에서 옵셔널 체이닝을 제거하였습니다. 두 값은 값이 없을 때 빈 배열을 넘겨주고 에러가 발생하였을 때는 에러를 던져서 해당 컴포넌트가 마운트되지 않기 때문에 두 값이 null이거나 undefined가 되지 않는다고 생각해서 옵셔널 체이닝이 필요 없다고 생각하였습니다.

## 관련 이슈

closes #286 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정