### PR TITLE
fix: spinner가 중복으로 표시되는 문제 해결

### DIFF
--- a/service-apply/src/assets/spinner.css
+++ b/service-apply/src/assets/spinner.css
@@ -9,12 +9,11 @@
   box-sizing: border-box;
   display: block;
   position: absolute;
-  left: calc(50% - 40px);
-  top: calc(50% - 40px);
-  transform: translate(-50%, -50%);
+  left: 50%;
+  top: 50%;
   width: 80px;
   height: 80px;
-  margin: 8px;
+  margin: -40px 0 0 -40px;
   border: 8px solid black;
   border-radius: 50%;
   animation: lds-ring 1.2s 1s cubic-bezier(0.5, 0, 0.5, 1) infinite;


### PR DESCRIPTION
## 주요 변경사항
### 변경 전
![제목 없는 동영상 - Clipchamp로 제작1](https://github.com/user-attachments/assets/d2c066d6-5176-43be-86b5-25603a7b429d)

### 변경 후
![제목 없는 동영상 - Clipchamp로 제작](https://github.com/user-attachments/assets/e4c47226-00c9-4356-b00b-075a4ac066b9)

## 리뷰어에게
spinner가 중복으로 표시되는 문제를 해결하였습니다.

## 관련 이슈

closes #61 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
